### PR TITLE
Connecting the user auth endpoints to client-side

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,28 +1,41 @@
-import { Route, Routes } from "react-router-dom"
 import './App.css'
+import { Route, Routes } from "react-router-dom"
 import Login from './pages/Login'
 import Register from './pages/Register'
 import NotFound from './pages/_NotFound'
 import AdminDashboard from './pages/admin/AdminDashboard'
 import ProtectedRoute from "./contexts/ProtectedRoutes"
 import GuestDashboard from "./pages/guests/GuestDashboard"
+import Homepage from "./pages/Homepage"
+import { useUserContext } from "./contexts/AuthContext"
+import { useEffect } from "react"
+import useTokenHandler from './hooks/useTokenHandler'
 
 const App = () => {
+  const { setIsAuthenticated } = useUserContext();
+  useTokenHandler();
+
+  useEffect(() => {
+    const session = localStorage.getItem("access_token");
+
+    if (session) {
+      setIsAuthenticated(true);
+    }
+  }, [setIsAuthenticated]);
+
+
   return (
     <>
       <Routes>
+        <Route path="/" element={<Homepage />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Register />} />
-        <Route path="/guest" element={
-          <ProtectedRoute role={localStorage.getItem("role")} requiredRole="guest">
-            <Route path="/" element={<GuestDashboard />} />
-          </ProtectedRoute>
-        } />
-        <Route path="/admin" element={
-          <ProtectedRoute role={localStorage.getItem("role")} requiredRole="admin">
-            <Route path="/" element={<AdminDashboard />} />
-          </ProtectedRoute>
-        } />
+        <Route element={<ProtectedRoute requiredRole="guest" />}>
+          <Route path="/guest" element={<GuestDashboard />} />
+        </Route>
+        <Route element={<ProtectedRoute requiredRole="admin" />}>
+          <Route path="/admin" element={<AdminDashboard />} />
+        </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>
     </>

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useState, useContext, ReactNode, FC } from "react";
+import { createContext, useState, useContext, ReactNode, FC, useEffect } from "react";
 
 interface UserDetails {
     username: string;
@@ -14,6 +14,7 @@ interface UserContextType {
     setIsAuthenticated: (value: boolean) => void;
     setUserDetails: (value: UserDetails) => void;
     setSessionExpired: (value: boolean) => void;
+    setRole: (value: string) => void;
 }
 
 const UserContext = createContext<UserContextType | any>(null);
@@ -25,14 +26,22 @@ export const UserProvider: FC<{ children: ReactNode }> = ({ children }) => {
         email: ''
     });
     const [sessionExpired, setSessionExpired] = useState<boolean>(false);
+    const [role, setRole] = useState(() => {
+        return localStorage.getItem("role") || "guest";
+    });
 
+    useEffect(() => {
+        localStorage.setItem("role", role);
+    }, [role]);
+    
     const contextValue: UserContextType = {
         isAuthenticated,
         userDetails,
         sessionExpired,
         setIsAuthenticated,
         setUserDetails,
-        setSessionExpired
+        setSessionExpired,
+        setRole,
     }
 
     return (

--- a/client/src/contexts/ProtectedRoutes.tsx
+++ b/client/src/contexts/ProtectedRoutes.tsx
@@ -1,22 +1,21 @@
 import { FC, ReactNode } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, Outlet } from "react-router-dom";
+import { useUserContext } from "./AuthContext";
 
 interface ProtectedRouteProps {
-  role: string | null;
   requiredRole: string;
-  children: ReactNode;
+  children?: ReactNode;
 }
 
-const ProtectedRoute: FC<ProtectedRouteProps> = ({ role, requiredRole, children }) => {
-  if (!localStorage.getItem('access_token') || role !== requiredRole) {
-    return <Navigate to="/" />
+const ProtectedRoute: FC<ProtectedRouteProps> = ({ requiredRole, children }) => {
+  const { isAuthenticated } = useUserContext();
+  const role = localStorage.getItem("role");
+
+  if (!isAuthenticated || role !== requiredRole) {
+    return <Navigate to="/" replace />;
   }
-  
-  return (
-    <>
-      {children}
-    </>
-  )
+
+  return children ? <>{children}</> : <Outlet />;
 }
 
 export default ProtectedRoute;

--- a/client/src/hooks/useTokenHandler.tsx
+++ b/client/src/hooks/useTokenHandler.tsx
@@ -1,8 +1,26 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { userAuth } from "../services/Token";
+import { useUserContext } from "../contexts/AuthContext";
 
 const useTokenHandler = () => {
-  return (
-    <div>useTokenHandler</div>
-  )
+  const { setIsAuthenticated } = useUserContext();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const validateToken = async () => {
+      try {
+        const authStatus = await userAuth();
+        setIsAuthenticated(authStatus);
+      } catch (error) {
+        console.error(`Failed to validate token: ${error}`);
+        navigate('/');
+        setIsAuthenticated(false);
+      }
+    }
+
+    validateToken();
+  }, [setIsAuthenticated, navigate]);
 }
 
-export default useTokenHandler
+export default useTokenHandler;

--- a/client/src/hooks/useUserRoles.tsx
+++ b/client/src/hooks/useUserRoles.tsx
@@ -1,8 +1,18 @@
+import { useCallback } from "react";
+import { useUserContext } from "../contexts/AuthContext";
 
-const useUserRoles = () => {
-  return (
-    <div>useUserRoles</div>
-  )
-}
+const useUserRole = () => {
+  const { role, setRole } = useUserContext();
 
-export default useUserRoles
+  const changeRole = useCallback(() => {
+    const newRole = role === "admin" ? "guest" : "admin";
+    setRole(newRole);
+    localStorage.setItem("role", newRole);
+  }, [role, setRole]);
+
+  const changeRoleFromRegister = () => setRole("guest");
+
+  return { role, changeRole, changeRoleFromRegister };
+};
+
+export default useUserRole;

--- a/client/src/layout/AdminSidebar.tsx
+++ b/client/src/layout/AdminSidebar.tsx
@@ -1,0 +1,8 @@
+
+const AdminSidebar = () => {
+  return (
+    <div>AdminSidebar</div>
+  )
+}
+
+export default AdminSidebar

--- a/client/src/layout/GuestSidebar.tsx
+++ b/client/src/layout/GuestSidebar.tsx
@@ -1,0 +1,8 @@
+
+const GuestSidebar = () => {
+  return (
+    <div>GuestSidebar</div>
+  )
+}
+
+export default GuestSidebar

--- a/client/src/layout/Sidebar.tsx
+++ b/client/src/layout/Sidebar.tsx
@@ -1,8 +1,0 @@
-
-const Sidebar = () => {
-  return (
-    <div>Sidebar</div>
-  )
-}
-
-export default Sidebar

--- a/client/src/pages/Homepage.tsx
+++ b/client/src/pages/Homepage.tsx
@@ -1,9 +1,14 @@
+import { Link } from "react-router-dom"
+import Footer from "../layout/Footer"
+import Navbar from "../layout/Navbar"
 
 const Homepage = () => {
   return (
-    <section>
-      
-    </section>
+    <>
+      <Navbar />
+      <Link to="/login" className="text-2xl underline">Login</Link>
+      <Footer />
+    </>
   )
 }
 

--- a/client/src/pages/admin/AdminDashboard.tsx
+++ b/client/src/pages/admin/AdminDashboard.tsx
@@ -19,7 +19,7 @@ const AdminDashboard = () => {
   
   return (
     <>
-      <div>AdminDashboard</div>
+      <div>Hello Admin!</div>
       <button onClick={handleLogout} className="bg-blue-500 p-4 border-2 border-gray-600 text-white rounded-md">Log Out</button>
     </>
   )

--- a/client/src/pages/guests/GuestDashboard.tsx
+++ b/client/src/pages/guests/GuestDashboard.tsx
@@ -1,7 +1,7 @@
 
 const GuestDashboard = () => {
   return (
-    <div>GuestDashboard</div>
+    <div>Hello Guest</div>
   )
 }
 

--- a/client/src/services/Auth.ts
+++ b/client/src/services/Auth.ts
@@ -1,13 +1,13 @@
-import API from "./_axios";
+import { API } from "./_axios";
 
-export const guestLogin = async (email: string, password: string) => {
+export const login = async (email: string, password: string) => {
     try {
-        const response = await API.post('/api/guest/login', {
+        const response = await API.post('/auth/login', {
             email: email,
             password: password
         }, {
             headers: {
-                'Content-Type': 'application/json',
+                'Content-Type': 'application/json'
             }
         });
         return response;
@@ -19,14 +19,10 @@ export const guestLogin = async (email: string, password: string) => {
 
 export const guestSignup = async (email: string, password: string, confirmPassword: string) => {
     try {
-        const response = await API.post('/api/guest/signup', {
+        const response = await API.post('/auth/signup', {
             email: email,
             password: password,
             confirmPassword: confirmPassword,
-        }, {
-            headers: {
-                'Content-Type': 'application/json',
-            }
         });
         return response;
     } catch (error) {
@@ -35,31 +31,15 @@ export const guestSignup = async (email: string, password: string, confirmPasswo
     }
 };
 
-export const adminLogin = async (email: string, password: string) => {
-    try {
-        const response = await API.post('/api/admin/login', {
-            email: email,
-            password: password
-        }, {
-            withCredentials: true
-        });
-        console.log(`Admin Access Token: ${response.data.access}`);
-        console.log(`Admin Refresh Token: ${response.data.refresh}`);
-        console.log(`Role: ${response.data.role}`);
-        return response;
-    } catch (error) {
-        console.error(`Failed to login: ${error}`);
-        throw error;
-    }
-};
-
 export const logout = async () => {
     try {
-        const response = await API.post('/api/auth/logout', {}, {
-            headers: {
-                'Authorization': `Bearer ${localStorage.removeItem('access_token')}`
-            },
-            withCredentials: true
+        const access_token = localStorage.getItem('access_token');
+        const refresh_token = localStorage.getItem('refresh_token');
+
+        if (!access_token) throw new Error('Access token not found');
+
+        const response = await API.post('/auth/logout', {
+            refresh: refresh_token
         });
         console.log(`Admin Access Token: ${response.data.access}`);
         console.log(`Admin Refresh Token: ${response.data.refresh}`);
@@ -77,12 +57,8 @@ export const logout = async () => {
 
 export const sendEmailOtp = async (email: string) => {
     try {
-        const response = await API.post('/api/email/otp', {
+        const response = await API.post('/email/otp', {
             email: email
-        }, {
-            headers: {
-                'Content-Type': 'application/json',
-            }
         });
         return response;
     } catch (error) {
@@ -93,12 +69,8 @@ export const sendEmailOtp = async (email: string) => {
 
 export const resendEmailOtp = async (email: string) => {
     try {
-        const response = await API.post('/api/otp-resend', {
+        const response = await API.post('/otp-resend', {
             email: email
-        }, {
-            headers: {
-                'Content-Type': 'application/json',
-            }
         });
         return response;
     } catch (error) {

--- a/client/src/services/Token.ts
+++ b/client/src/services/Token.ts
@@ -1,19 +1,52 @@
-import Cookies from "universal-cookie"
+import axios from "axios";
+import { jwtDecode } from "jwt-decode";
 
-const cookies = new Cookies();
-
-export const getAccessTokenForAdmin = () => {
-    return cookies.get('admin_token');
+export const isTokenExpired = (token: string): boolean => {
+    const decoded : { exp: number } = jwtDecode(token);
+    const tokenExpiration = decoded.exp;
+    const currentTime = Date.now() / 1000;
+    return tokenExpiration < currentTime;
 };
 
-export const getRefreshTokenForAdmin = () => {
-    return cookies.get('admin_refresh');
+export const refreshUserToken = async () => {
+    const refreshToken = localStorage.getItem("refresh_token");
+    if (!refreshToken) return false;
+    if (isTokenExpired(refreshToken)) {
+        localStorage.removeItem("access_token");
+        localStorage.removeItem("refresh_token");
+        localStorage.removeItem("role");
+        return false;
+    }
+
+    try {
+        const response = await axios.post("/auth/refresh", {
+            refresh: refreshToken,
+        });
+
+        if (response.status === 200) {
+            localStorage.setItem("refresh_token", response.data.refresh);
+            return true;
+        }
+        return false;
+    } catch (error) {
+        console.error(`Failed to refresh token: ${error}`);
+        return false;
+    }
 };
 
-export const getAccessTokenForGuests = () => {
-    return cookies.get('access_token');
-};
+export const userAuth = async (): Promise<boolean> => {
+    const accessToken = localStorage.getItem("access_token");
 
-export const getRefreshTokenForGuests = () => {
-    return cookies.get('refesh_token');
-};
+    if (!accessToken) {
+        console.log("No access token found");
+        return false;
+    }
+
+    if (isTokenExpired(accessToken)) {
+        const response = await refreshUserToken();
+        return response ?? false;
+    }
+
+    console.log("Token expiry checked.");
+    return true;
+}

--- a/client/src/services/_axios.ts
+++ b/client/src/services/_axios.ts
@@ -1,7 +1,8 @@
 import axios from "axios";
 
-const API = axios.create({
-    baseURL: import.meta.env.VITE_API_URL,
+export const API = axios.create({
+    baseURL: `${import.meta.env.VITE_API_URL}/api`,
+    headers: {
+        'Content-Type': 'application/json',
+    }
 });
-
-export default API;

--- a/server/hotel_backend/user_roles/urls.py
+++ b/server/hotel_backend/user_roles/urls.py
@@ -5,9 +5,8 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 urlpatterns = [
     path('token', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('token/refresh', TokenRefreshView.as_view(), name="token_refresh_pair"),
-    path('admin/login', views.admin_login, name='admin_login'),
-    path('guest/signup', views.guest_register, name='guest_register'),
-    path('guest/login', views.guest_login, name='guest_login'),
-    path('auth/logout', views.logout, name='logout'),
+    path('auth/login', views.user_login, name='user_login'),
+    path('auth/signup', views.guest_register, name='guest_register'),
+    path('auth/logout', views.auth_logout, name='logout'),
     path('email/send-otp', views.send_register_otp, name='send_register_otp'),
 ]


### PR DESCRIPTION
interrelated to PR #9 :

added:
- custom hook for token handling in client-side
- contexts for user authentication, handling its global state
- some test pages for admin and guests
- template layouts

test pending:
- can do login (as guest only, so you can't register your sample email here)

updates:
- user auth business logic fixes
- API endpoints

removed:
- separate endpoint for admin and login

to be implemented next:
- server-side validation